### PR TITLE
 Translation of a sentence and correction of a display bug

### DIFF
--- a/web_app_frontend/src/game/gameScenes/MainScene.js
+++ b/web_app_frontend/src/game/gameScenes/MainScene.js
@@ -96,6 +96,7 @@ class MainScene extends Phaser.Scene {
         this.hero = null; //Reset hero
         this.score = 0; //Reset score
         this.scoreSaved = false; // Reset score saved flag
+        this.previousScoreCheckpoint = 0; // Resets the last control point
     }
 
     //------------------------------------------------HERO------------------------------------------------
@@ -293,7 +294,7 @@ class MainScene extends Phaser.Scene {
     //Message indicating the number of meters traveled and the increase 
     //in the number of characters in a string as a function of this distance.
     showMilestoneMessage(distance, maxSequence) {
-        const message = `${distance} m parcourus ! Passage à ${maxSequence} caractères !`;
+        const message = `${distance} metres travelled ! Switch to ${maxSequence} letters !`;
     
         //Create the text at the center-top of the screen
         const milestoneText = this.add.text(


### PR DESCRIPTION
In the running game, translation of the phrase "Passage à ... carctères" into English
Fixed a display bug that caused enemies to have 2 letters directly associated with them when a game was restarted after a game over